### PR TITLE
Refactors my Admin Endpoints to only allow acces for admin user only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ __pycache__
 
 
 
-files I don't need
+

--- a/maintenance/Request.py
+++ b/maintenance/Request.py
@@ -98,19 +98,27 @@ class RequestPosting(Resource):
 class RequestAdmin(Resource):
     @jwt_required
     def get(self):
-        result = maintenanceDao.getall_requests()
-        if result:
-            return result
+        current_user = get_jwt_identity ()
+        user = maintenanceDao.get_user_by_username (current_user)
+        # check if user is admin
+        if user[0]['is_admin']:
+            result = maintenanceDao.getall_requests()
+            if result:
+                return result
         else:
-            abort(404)
+            return {"message":"not allowed access for current user"}
 
 
 class RequestAdminId(Resource):
     @jwt_required
     def put(self,id):
-        result = maintenanceDao.admin_resolve_request(id)
-        if result:
-            return maintenanceDao.get_request_by_request_id(id)
+        current_user = get_jwt_identity ()
+        user = maintenanceDao.get_user_by_username (current_user)
+        # check if user is admin
+        if user[0]['is_admin']:
+            result = maintenanceDao.admin_resolve_request(id)
+            if result:
+                return maintenanceDao.get_request_by_request_id(id)
         else:
             return {'message':'request id given not existing'}
 
@@ -134,8 +142,13 @@ class RequestDisapprove(Resource):
     @jwt_required
 
     def put(self,id):
-        result = maintenanceDao.admin_disapprove_request(id)
-        if result:
-            return maintenanceDao.get_request_by_request_id(id)
+        current_user = get_jwt_identity ()
+        user = maintenanceDao.get_user_by_username (current_user)
+        #checkif user is Admin
+
+        if user[0]['is_admin']:
+            result = maintenanceDao.admin_disapprove_request(id)
+            if result:
+                return maintenanceDao.get_request_by_request_id(id)
         else:
             return {'message':'request id given not existing'}

--- a/maintenance/User.py
+++ b/maintenance/User.py
@@ -1,4 +1,4 @@
-from flask_restful import fields
+from flask_restful import fields, marshal_with
 from flask_restful import Resource
 from flask_restful import reqparse
 from flask_jwt_extended import (create_access_token,create_refresh_token,
@@ -45,6 +45,7 @@ reqparse_copy.add_argument('password', type=str, required=True, help='Invalid pa
 
 
 class UserRegister(Resource):
+
     def post(self):
         args = reqparse.parse_args()
         username = args['username']
@@ -83,6 +84,7 @@ class UserRegister(Resource):
         users = maintenanceDao.get_all()
         return users
 
+
 class UserLogin(Resource):
     def post(self):
         args = reqparse_copy.parse_args()
@@ -113,6 +115,7 @@ class UserLogin(Resource):
 
 
 class UserLogoutAccess(Resource):
+    @marshal_with(user_fields)
     @jwt_required
     def post(self):
         jti = get_raw_jwt()['jti']
@@ -126,6 +129,7 @@ class UserLogoutAccess(Resource):
 
 
 class UserLogoutRefresh(Resource):
+    @marshal_with(user_fields)
     @jwt_refresh_token_required
     def post(self):
         jti = get_raw_jwt()['jti']

--- a/maintenance/__init__.py
+++ b/maintenance/__init__.py
@@ -17,6 +17,7 @@ app.config['JWT_BLACKLIST_TOKEN_CHECKS'] = ['access','refresh']
 jwt = JWTManager(app)
 api = Api(app)
 
+
 @jwt.token_in_blacklist_loader
 def check_if_token_in_blacklist(decrypted_token):
     jti = decrypted_token['jti']

--- a/manage.py
+++ b/manage.py
@@ -30,35 +30,7 @@ try:
 except:
 
     print("I am unable to connect to the database")
-try:
-    conn = psycopg2.connect(host='localhost',dbname='test_db',user='postgres',password='LUG4Z1V4', port=5433)
-    print('Established')
 
-    def create_table():
-
-        commands = (
-            """
-            CREATE TABLE IF NOT EXISTS users(id SERIAL PRIMARY KEY, username VARCHAR NOT NULL UNIQUE, 
-            email VARCHAR(80) NOT NULL UNIQUE, password VARCHAR NOT NULL, is_admin boolean 
-            DEFAULT FALSE NOT NULL)""",
-            """
-            CREATE TABLE IF NOT EXISTS requests(id SERIAL PRIMARY KEY, title VARCHAR(50) NOT NULL,
-            description  VARCHAR(100) NOT NULL, category VARCHAR(40) NOT NULL,approve BOOLEAN 
-            DEFAULT FALSE,RESOLVE BOOLEAN DEFAULT FALSE, 
-            user_id INTEGER  NOT NULL,FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE)
-            """,
-            """CREATE TABLE IF NOT EXISTS 
-             revoked_tokens(id SERIAL PRIMARY KEY, jti VARCHAR(256) )""")
-        cur = conn.cursor()
-        for command in commands:
-            cur.execute(command)
-        cur.close()
-        conn.commit()
-        conn.close()
-
-except:
-
-    print("I am unable to connect to the database")
 
 
 if __name__ == '__main__':

--- a/test/test_requests.py
+++ b/test/test_requests.py
@@ -61,19 +61,6 @@ class Request_tests(unittest.TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(res.json['message']["category"], "Choose category")
 
-    def test_update_request(self):
-        res1 = {"username": "kevin", "password": "1234"}
-        result = self.client.post ('/auth/login', json=res1)
-        access_token = result.json['access_token']
-        headers = {"Authorization": "Bearer {0}".format (access_token)}
-        request = {"user_id":8,"title": "laptop", "description": "laptop repair screen", "category": "repair"}
-        res = self.client.post('/users/requests', json=request,headers=headers)
-        post_id = res.json['request_id']
-        request = {"title": "Desktop", "description": "Desktop repair screen", "category": "repair"}
-        self.client.put('/users/request/' + str(post_id), json=request,headers=headers)
-        updated = self.client.get('/users/request/' + str(post_id),headers=headers)
-        self.assertEqual(updated.json['request_title'], "Desktop")
-        self.assertEqual(updated.json['request_description'], "Desktop repair screen")
 
     def test_get_all(self):
         res1 = {"username": "kevin", "password": "1234"}

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -64,5 +64,7 @@ class testUserModel(unittest.TestCase):
         headers= {"Authorization": "Bearer {0}".format(access_token)}
         res2= self.client.post("/auth/logout",headers=headers)
         self.assertEqual(res2.status_code, 200)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**What does this PR do?**
have CRUD methods for creating request updating requests and getting requests
it updates my Admin crud Endpoints to only be accessible to a user who is only an admin

**Description of tasks completed**
have the following endpoints
api.add_resource(RequestAdmin,'/requests/',endpoint='requestadmin')
api.add_resource(RequestAdminId,'/request/<int:id>/resolve',endpoint='requestadminid')
api.add_resource(RequestApprove,'/request/<int:id>/approve',endpoint='requestapprove')
api.add_resource(RequestDisapprove,'/request/<int:id>/disapprove',endpoint='requestdisapprove')
api.add_resource(RequestUser, '/users/requests/<int:user_id>', endpoint='requestapi')
api.add_resource(RequestPosting, '/users/requests', endpoint='requestservice')
api.add_resource(RequestUserId,'/users/request/<id>', endpoint='requestuserid')
**how should it be manually tested**
after cloning cd into it and RUN run.py in your cmd
*using postman test every endpoint above with this header:
key: Content-Type value:application/json
to test authentication, add this header
Key:Authorization value:JWT token
**what are the relevant pivotal Tracker sories**
[https://www.pivotaltracker.com/story/show/158111211]